### PR TITLE
fix (root): GH_TOKEN이 없어서 "gh" cli 사용이 실패되는 문제 수정

### DIFF
--- a/.github/workflows/npm-deploy-utils.yaml
+++ b/.github/workflows/npm-deploy-utils.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   deploy-npm-utils:
     permissions:


### PR DESCRIPTION
## 개요
전반적인  내용

- GH_TOKEN이 없어서 "gh" cli 사용이 실패되는 문제 수정

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
Error: Process completed with exit code 4.
```

## PR 유형
어떤 변경 사항이 있나요?

- [ ] (feature) 새로운 기능 추가
- [x] (fix) 버그 수정 및 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] (style) CSS 등 사용자 UI 디자인 변경
- [ ] (refactor) 코드 리팩토링
- [ ] (docs) 문서 수정
- [ ] (test) 테스트 추가, 테스트 리팩토링
- [ ] (chore) 빌드 부분 혹은 패키지 매니저 수정
